### PR TITLE
impl tracing layer for span timing collection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,6 +158,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +258,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,10 +367,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
@@ -506,6 +580,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +602,15 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "overload"
@@ -574,6 +666,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +690,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -651,6 +782,10 @@ dependencies = [
  "axum",
  "clap",
  "color-eyre",
+ "dashmap",
+ "derive_more",
+ "ordered-float",
+ "rand",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -943,6 +1078,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1063,3 +1210,24 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ edition = "2024"
 axum = "0.8.1"
 clap = { version = "4.5.27", features = ["derive"] }
 color-eyre = "0.6.3"
+dashmap = "6.1.0"
+derive_more = { version = "1.0.0", features = ["full"] }
+ordered-float = "4.6.0"
+rand = "0.8.5"
 tokio = { version = "1.43.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,4 @@
+allow-unwrap-in-tests = true
+allow-expect-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-panic-in-tests = true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src/main.rs"

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,280 @@
+//! # Logging Module
+
+use std::{
+	collections::{BTreeMap, HashMap},
+	sync::Arc,
+	time::{Duration, Instant}
+};
+
+use dashmap::DashMap;
+use derive_more::derive::Display;
+use ordered_float::NotNan;
+use rand::{Rng, thread_rng};
+use tracing::{
+	Subscriber,
+	span::{Attributes, Id}
+};
+use tracing_subscriber::{Layer, layer::Context, registry::LookupSpan};
+
+/// Execution time statistics for a span
+#[derive(Display, Debug)]
+#[display("{:#?}", self)]
+pub struct SpanTimingsLayerStatistics {
+	/// Number of times the span was entered-exited
+	pub count: usize,
+	/// Total time spent in the span
+	pub total: Duration,
+	/// Minimum of "time spent in single enter-exit of this span"
+	pub min: Duration,
+	/// Average of "time spent in single enter-exit of this span"
+	pub avg: Duration,
+	/// Maximum of "time spent in single enter-exit of this span"
+	pub max: Duration,
+	/// Percentiles of "time spent in single enter-exit of this span"
+	pub percentiles: BTreeMap<NotNan<f64>, Duration>
+}
+
+/// Wrapper around [`Instant`] to store the time a span was started
+struct StartedAt(Instant);
+
+/// [`tracing`] layer to collect execution timings of spans
+///
+/// this layer stores a timestamp on every span enter event,
+/// and calculates the duration once the span is exited
+/// and stores it in a vec for every distinct span name
+pub struct SpanTimingsLayer {
+	/// map of span names to their execution durations
+	span_timings: Arc<DashMap<String, BTreeMap<Duration, usize>>>,
+	/// max number of timing datapoints to store per span
+	max_timing_datapoints_per_span: usize
+}
+
+/// Arc pointer to the span timings map
+///
+/// `.clone()` is essentially an [`Arc::clone()`] thus cheap
+#[derive(Clone)]
+pub struct SpanTimingsPtr(Arc<DashMap<String, BTreeMap<Duration, usize>>>);
+
+impl SpanTimingsPtr {
+	/// Get the map containing [`SpanTimingsLayerStatistics`] for each spans
+	///
+	/// percentiles must be [0.0, 100.0) - otherwise they will be ignored
+	pub fn get_statistics(
+		&self,
+		percentiles: &[f64]
+	) -> HashMap<String, SpanTimingsLayerStatistics> {
+		self.0
+			.iter()
+			.filter_map(|kv| {
+				let (name, timings) = kv.pair();
+
+				let count = timings.iter().fold(0, |acc, (_, c)| acc + *c);
+				let total = timings
+					.iter()
+					.fold(Duration::ZERO, |acc, (d, c)| acc + *d * *c as u32);
+
+				Some((name.clone(), SpanTimingsLayerStatistics {
+					count,
+					total,
+					min: *timings.keys().min()?,
+					avg: total / count as u32,
+					max: *timings.keys().max()?,
+					percentiles: percentiles
+						.iter()
+						.filter_map(|&p| {
+							let p = NotNan::new(p).ok()?;
+							if *p < 0.0 || *p >= 100.0 {
+								return None;
+							}
+							let idx =
+								(count as f64 * *p / 100.0).floor() as usize;
+							timings
+								.iter()
+								.fold((None, 0), |(found, cur), (d, c)| {
+									let cur = cur + *c;
+									if found.is_none() && cur > idx {
+										return (Some(*d), cur);
+									}
+									(found, cur)
+								})
+								.0
+								.map(|d| (p, d))
+						})
+						.collect()
+				}))
+			})
+			.collect()
+	}
+}
+
+impl SpanTimingsLayer {
+	/// Create a new [`SpanTimingsLayer`]
+	///
+	/// `max_timings_per_span` is the maximum number of timing datapoints to store per span
+	///
+	/// if `max_timings_per_span` is 0, there will be no limit (not recommended for long-running programs)
+	///
+	/// once the limit is reached, a random datapoint will be removed
+	///
+	/// highly recommended to run with [`tracing_subscriber::EnvFilter`] to limit the number of spans,
+	/// otherwise the memory usage can grow significantly
+	/// ```rust
+	/// let (layer, _) = SpanTimingsLayer::new(100);
+	/// tracing_subscriber::registry().with(layer.with_filter(EnvFilter::new(format!("{}=info", env!("CARGO_PKG_NAME"))))).init();
+	/// ```
+	pub fn new(max_timings_per_span: usize) -> (Self, SpanTimingsPtr) {
+		let span_timings: Arc<DashMap<String, BTreeMap<Duration, usize>>> =
+			Arc::new(DashMap::new());
+
+		(
+			Self {
+				span_timings: Arc::clone(&span_timings),
+				max_timing_datapoints_per_span: max_timings_per_span
+			},
+			SpanTimingsPtr(span_timings)
+		)
+	}
+}
+
+impl<S> Layer<S> for SpanTimingsLayer
+where
+	S: Subscriber,
+	S: for<'lookup> LookupSpan<'lookup>
+{
+	fn on_new_span(
+		&self,
+		_attrs: &Attributes<'_>,
+		id: &Id,
+		ctx: Context<'_, S>
+	) {
+		#[allow(
+			clippy::unwrap_used,
+			reason = "we are inside on_new_span so this always succeeds"
+		)]
+		let span = ctx.span(id).unwrap();
+
+		span.extensions_mut().insert(StartedAt(Instant::now()));
+	}
+
+	fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+		let now = Instant::now();
+		#[allow(
+			clippy::unwrap_used,
+			reason = "we are inside on_close so this always succeeds"
+		)]
+		let span = ctx.span(&id).unwrap();
+
+		if let Some(started_at) = span.extensions().get::<StartedAt>() {
+			let mut timings = self
+				.span_timings
+				.entry(span.metadata().name().to_string())
+				.or_default();
+			if self.max_timing_datapoints_per_span != 0
+				&& timings.iter().fold(0, |acc, (_, c)| acc + *c)
+					>= self.max_timing_datapoints_per_span
+			{
+				let to_remove = if 1 < timings.len() - 1 {
+					thread_rng().gen_range(1..(timings.len() - 1))
+				} else {
+					0
+				};
+				#[allow(
+					clippy::unwrap_used,
+					reason = "to_remove is always in bounds"
+				)]
+				let target_key = *timings.keys().nth(to_remove).unwrap();
+				#[allow(
+					clippy::unwrap_used,
+					reason = "target_key always exists"
+				)]
+				let target_value = timings.get_mut(&target_key).unwrap();
+				if *target_value == 1 {
+					timings.remove(&target_key);
+				} else {
+					*target_value -= 1;
+				}
+			}
+			timings
+				.entry(now - started_at.0)
+				.and_modify(|c| *c += 1)
+				.or_insert(1);
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use tracing::*;
+	use tracing_subscriber::{
+		layer::SubscriberExt,
+		reload::Layer,
+		util::SubscriberInitExt
+	};
+
+	use super::*;
+
+	async fn foo() {
+		trace!("foo");
+	}
+
+	async fn bar() {
+		trace!("bar");
+	}
+
+	#[tokio::test]
+	async fn test_span_timings_layer() {
+		let (layer, ptr) = SpanTimingsLayer::new(0);
+		let (layer, handle) = Layer::new(layer);
+		tracing_subscriber::registry().with(layer).init();
+
+		for _ in 0..10 {
+			foo().instrument(info_span!("foo_span")).await;
+		}
+
+		// -1.0 and 100.0 is invalid and should be skipped
+		let stats = ptr.get_statistics(&[-1.0, 0.0, 50.0, 99.9, 100.0]);
+		assert_eq!(stats.len(), 1);
+		let stat = stats.get("foo_span").unwrap();
+		assert_eq!(stat.count, 10);
+		assert_eq!(stat.percentiles.keys().cloned().collect::<Vec<_>>(), vec![
+			NotNan::new(0.0).unwrap(),
+			NotNan::new(50.0).unwrap(),
+			NotNan::new(99.9).unwrap()
+		]);
+
+		// test bounded timings layer
+		let (layer, ptr) = SpanTimingsLayer::new(1);
+		handle.reload(layer).unwrap();
+
+		for _ in 0..10 {
+			foo().instrument(info_span!("foo_span")).await;
+			bar().instrument(info_span!("bar_span")).await;
+		}
+
+		// -1.0 and 100.0 is invalid and should be skipped
+		let stats = ptr.get_statistics(&[-1.0, 0.0, 50.0, 99.9, 100.0]);
+		assert_eq!(stats.len(), 2);
+		let stat = stats.get("foo_span").unwrap();
+		assert_eq!(stat.count, 1);
+		assert_eq!(stat.percentiles.keys().cloned().collect::<Vec<_>>(), vec![
+			NotNan::new(0.0).unwrap(),
+			NotNan::new(50.0).unwrap(),
+			NotNan::new(99.9).unwrap()
+		]);
+		let stat = stats.get("bar_span").unwrap();
+		assert_eq!(stat.count, 1);
+
+		// test bounded timings rand drop
+		let (layer, ptr) = SpanTimingsLayer::new(10);
+		handle.reload(layer).unwrap();
+
+		for _ in 0..100 {
+			foo().instrument(info_span!("foo_span")).await;
+		}
+
+		let stats = ptr.get_statistics(&[50.0]);
+		assert_eq!(stats.len(), 1);
+		let stat = stats.get("foo_span").unwrap();
+		assert_eq!(stat.count, 10);
+	}
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,18 @@
-#![warn(missing_debug_implementations)]
+#![warn(
+	missing_debug_implementations,
+	missing_docs,
+	clippy::missing_docs_in_private_items,
+	clippy::unwrap_used,
+	clippy::expect_used,
+	clippy::indexing_slicing,
+	clippy::panic,
+	clippy::todo,
+	clippy::unimplemented,
+	clippy::unreachable
+)]
+#![feature(let_chains)]
+
+//! Rune Server
 
 use std::{
 	env,
@@ -8,6 +22,7 @@ use std::{
 use axum::{Router, routing::get};
 use clap::Parser;
 use color_eyre::eyre::Result;
+use logging::SpanTimingsLayer;
 use tokio::net::TcpListener;
 use tracing::*;
 use tracing_subscriber::{
@@ -18,6 +33,8 @@ use tracing_subscriber::{
 	util::SubscriberInitExt
 };
 
+mod logging;
+
 /// Rune Server
 #[derive(Debug, Parser)]
 struct Args {
@@ -25,8 +42,12 @@ struct Args {
 	#[clap(short = 'a', long, default_value = "127.0.0.1")]
 	bind_address: Ipv4Addr,
 	/// Port
-	#[clap(short = 'p', long, default_value = "8080")]
-	port: u16
+	#[clap(short = 'p', long, default_value_t = 8080)]
+	port: u16,
+	/// Max instrumenting datapoints to keep per span.
+	/// Set to 0 to not keep any
+	#[clap(long, default_value_t = 1000)]
+	num_max_instrument_points: usize
 }
 
 #[tokio::main]
@@ -40,12 +61,45 @@ async fn main() -> Result<()> {
 			.unwrap_or_else(|_| format!("{}=info", env!("CARGO_PKG_NAME")))
 	);
 	let fmt_layer = fmt::layer().with_span_events(FmtSpan::CLOSE);
+	let (timings_layer, span_timings_ptr) =
+		if args.num_max_instrument_points != 0 {
+			let (timings_layer, span_timings_ptr) =
+				SpanTimingsLayer::new(args.num_max_instrument_points);
+			(Some(timings_layer), Some(span_timings_ptr))
+		} else {
+			(None, None)
+		};
 	tracing_subscriber::registry()
 		.with(fmt_layer.with_filter(env_filter))
+		.with(timings_layer.with_filter(EnvFilter::new(format!(
+			"{}=info",
+			env!("CARGO_PKG_NAME")
+		))))
 		.init();
 
 	// build server with a route
-	let server = Router::new().route("/", get(|| async { "Hello, world!" }));
+	let server = Router::new()
+		.route(
+			"/",
+			get(|| async { "Hello, world!" }.instrument(info_span!("/")))
+		)
+		.route(
+			"/debug",
+			get(move || {
+				async move {
+					if let Some(span_timings_ptr) = span_timings_ptr {
+						format!(
+							"{:#?}",
+							span_timings_ptr
+								.get_statistics(&[50.0, 90.0, 99.0, 99.9])
+						)
+					} else {
+						"Span timings not enabled".to_string()
+					}
+				}
+				.instrument(info_span!("/debug"))
+			})
+		);
 
 	let listener =
 		TcpListener::bind(SocketAddr::new(args.bind_address.into(), args.port))


### PR DESCRIPTION
^as title

Run the server:
```
cargo run --release
```
Run concurrent requests (repeat below command a couple times):
```
for i in {1..10000}; do (curl -fsSL http://127.0.0.1:8080 &> /dev/null & curl -fsSL http://127.0.0.1:8080/debug &> /dev/null & echo $i); done
```
Stat shows up correctly:
```
$ curl -fsSL http://127.0.0.1:8080/debug
{
    "/": SpanTimingsLayerStatistics {
        count: 1000,
        total: 13.5584ms,
        min: 3.042µs,
        avg: 13.558µs,
        max: 1.485584ms,
        percentiles: {
            50.0: 9.25µs,
            90.0: 16.125µs,
            99.0: 66.792µs,
            99.9: 1.485584ms,
        },
    },
    "/debug": SpanTimingsLayerStatistics {
        count: 1000,
        total: 70.728869ms,
        min: 12.292µs,
        avg: 70.728µs,
        max: 5.256417ms,
        percentiles: {
            50.0: 48.25µs,
            90.0: 113.75µs,
            99.0: 257.25µs,
            99.9: 5.256417ms,
        },
    },
}
```