### PR TITLE
Feat: add static serving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 # see https://docs.rs/sqlx/latest/sqlx/mysql/struct.MySqlConnectOptions.html
 DATABASE_URL=mysql://username:password@localhost/rune?socket=/tmp/mysql.sock
+SERVE_DIR=frontend/dist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
+
+[[package]]
 name = "httparse"
 version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1075,16 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1442,6 +1458,7 @@ dependencies = [
  "rand",
  "sqlx",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]
@@ -2081,6 +2098,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2091,6 +2121,31 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "http-range-header",
+ "httpdate",
+ "mime",
+ "mime_guess",
+ "percent-encoding",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2185,6 +2240,12 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ sqlx = { version = "0.8.3", features = [
     "migrate",
 ] }
 tokio = { version = "1.43.0", features = ["full"] }
+tower-http = { version = "0.6.2", features = ["fs", "trace"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 

--- a/frontend/src/app/(tabs)/_layout.tsx
+++ b/frontend/src/app/(tabs)/_layout.tsx
@@ -13,6 +13,15 @@ export default function TabLayout() {
           ),
         }}
       />
+      <Tabs.Screen
+        name="about"
+        options={{
+          title: "About",
+          tabBarIcon: ({ color }) => (
+            <IconSymbol name="house.fill" size={32} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/frontend/src/app/(tabs)/about.tsx
+++ b/frontend/src/app/(tabs)/about.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from "react-native";
+
+export default function About() {
+  return (
+    <View className="bg-blue-400">
+      <Text className="text-red-500 font-bold">About</Text>
+    </View>
+  );
+}


### PR DESCRIPTION

## Summary

- Add static serving for `/`

## Test Plan

- Build expo web

```bash
cd frontend
pnpm expo export --platform web
```

- Edit `.env`

```bash
SERVE_DIR=frontend/dist
```

- Start server

```bash
cargo run
```

- Access webpage and see the result
